### PR TITLE
fix memory bloat

### DIFF
--- a/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnThread.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnThread.java
@@ -80,6 +80,10 @@ class AdVpnThread implements Runnable, DnsPacketProxy.EventLoop {
     private Thread thread = null;
     private FileDescriptor mBlockFd = null;
     private FileDescriptor mInterruptFd = null;
+
+    Set<String> allowOnVpn = new HashSet<>();
+    Set<String> doNotAllowOnVpn = new HashSet<>();
+
     /**
      * Number of iterations since we last cleared the pcap4j cache
      */
@@ -388,9 +392,6 @@ class AdVpnThread implements Runnable, DnsPacketProxy.EventLoop {
     }
 
     void configurePackages(VpnService.Builder builder, Configuration config) {
-        Set<String> allowOnVpn = new HashSet<>();
-        Set<String> doNotAllowOnVpn = new HashSet<>();
-
         config.allowlist.resolve(vpnService.getPackageManager(), allowOnVpn, doNotAllowOnVpn);
 
         if (config.allowlist.defaultMode == Configuration.Allowlist.DEFAULT_MODE_NOT_ON_VPN) {


### PR DESCRIPTION
Hello,

We ran dns66 with our tool and detected the memory bloat issues. Memory bloat occurs by allocating and initializing many objects whose lifetimes do not overlap. For example, allocating objects in a loop where the object’s lifetime is only the scope of the loop body.

Our tool reports two objects (allowOnVpn and doNotAllowOnVpn) that account for 20% of cache misses in the entire program in file AdThreadVpn.java. The two problematic objects allowOnVpn and doNotAllowOnVpn are both repeatedly allocated in loops with no overlap in lifecycles across different instances. The optimized code is in this pull request.